### PR TITLE
feat(auto-test-cere-ddc): Adding test case to cover send data function

### DIFF
--- a/pallets/cere-ddc/src/lib.rs
+++ b/pallets/cere-ddc/src/lib.rs
@@ -1,10 +1,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage,
+	decl_error,
+	decl_event,
+	decl_module,
+	decl_storage,
 	// dispatch,
 	ensure,
-	traits::{ Get },
+	traits::Get,
 };
 use frame_system::ensure_signed;
 
@@ -52,7 +55,6 @@ decl_event!(
 	{
 		/// A data string was set. \[who\]
 		DataStringSet(AccountId),
-	
 		/// A data string was changed. \[who\]
 		DataStringChanged(AccountId),
 	}

--- a/pallets/cere-ddc/src/mock.rs
+++ b/pallets/cere-ddc/src/mock.rs
@@ -49,12 +49,17 @@ impl system::Trait for Test {
 	type SystemWeightInfo = ();
 }
 
+parameter_types! {
+	pub const MinLength: usize = 8;
+	pub const MaxLength: usize = 10;
+}
+
 impl Trait for Test {
 	type Event = ();
 
-	type MinLength = ();
+	type MinLength = MinLength;
 
-	type MaxLength = ();
+	type MaxLength = MaxLength;
 }
 
 pub type CereDDCModule = Module<Test>;

--- a/pallets/cere-ddc/src/mock.rs
+++ b/pallets/cere-ddc/src/mock.rs
@@ -56,9 +56,7 @@ parameter_types! {
 
 impl Trait for Test {
 	type Event = ();
-
 	type MinLength = MinLength;
-
 	type MaxLength = MaxLength;
 }
 

--- a/pallets/cere-ddc/src/tests.rs
+++ b/pallets/cere-ddc/src/tests.rs
@@ -4,7 +4,7 @@ use frame_support::{assert_noop, assert_ok};
 const BOB: u64 = 2;
 
 #[test]
-fn it_works_for_default_value() {
+fn send_data_works_valid_input() {
 	new_test_ext().execute_with(|| {
 		// Dispatch a signed extrinsic.
 		assert_ok!(CereDDCModule::send_data(Origin::signed(1), BOB, b"12345678".to_vec()));
@@ -12,7 +12,7 @@ fn it_works_for_default_value() {
 }
 
 #[test]
-fn correct_error_for_none_value() {
+fn send_data_error_too_long() {
 	new_test_ext().execute_with(|| {
 		// Ensure the expected error is thrown when no value is present.
 		assert_noop!(
@@ -23,7 +23,7 @@ fn correct_error_for_none_value() {
 }
 
 #[test]
-fn correct_error_for_short() {
+fn send_data_error_too_short() {
 	new_test_ext().execute_with(|| {
 		// Ensure the expected error is thrown when no value is present.
 		assert_noop!(

--- a/pallets/cere-ddc/src/tests.rs
+++ b/pallets/cere-ddc/src/tests.rs
@@ -1,5 +1,5 @@
-use crate::{mock::*};
-use frame_support::{assert_ok};
+use crate::{mock::*, Error};
+use frame_support::{assert_noop, assert_ok};
 
 const BOB: u64 = 2;
 
@@ -7,6 +7,28 @@ const BOB: u64 = 2;
 fn it_works_for_default_value() {
 	new_test_ext().execute_with(|| {
 		// Dispatch a signed extrinsic.
-		assert_ok!(CereDDCModule::send_data(Origin::signed(1), BOB, Vec::new()));
+		assert_ok!(CereDDCModule::send_data(Origin::signed(1), BOB, b"12345678".to_vec()));
+	});
+}
+
+#[test]
+fn correct_error_for_none_value() {
+	new_test_ext().execute_with(|| {
+		// Ensure the expected error is thrown when no value is present.
+		assert_noop!(
+			CereDDCModule::send_data(Origin::signed(1), BOB, b"TestTooLongString".to_vec()),
+			Error::<Test>::TooLong
+		);
+	});
+}
+
+#[test]
+fn correct_error_for_short() {
+	new_test_ext().execute_with(|| {
+		// Ensure the expected error is thrown when no value is present.
+		assert_noop!(
+			CereDDCModule::send_data(Origin::signed(1), BOB, b"Short".to_vec()),
+			Error::<Test>::TooShort
+		);
 	});
 }


### PR DESCRIPTION
Test coverage for DDC pallet. (Notion: [url](https://www.notion.so/cere/Test-coverage-for-DDC-pallet-b741f11f4ba5485091dbf18d7f7a6c13))